### PR TITLE
use valgrind to check memory leak

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -1,3 +1,20 @@
 
-all:
-	g++ slist_test.cpp ../kii_http.c -I. -I../ -o test -std=c++11
+TARGET=./testapp
+INCLUDES=-I. -I../
+all: clean $(TARGET)
+
+$(TARGET):
+	g++ slist_test.cpp ../kii_http.c $(INCLUDES) -o $(TARGET) -std=c++11
+
+test: $(TARGET)
+	$(TARGET) -r junit -o unit-test.xml
+
+memory-check: $(TARGET)
+	valgrind --leak-check=yes $(TARGET)
+clean:
+	touch $(TARGET)
+	rm $(TARGET)
+	touch unit-test.xml
+	rm unit-test.xml
+
+.PHONY: all clean test memory-check


### PR DESCRIPTION
### Changes
- refactor Makefile
- add `memory-check`, using valgrind to check memory leak