### PR TITLE
Added khc_set_zero_excl_cb() api.

### DIFF
--- a/include/khc.h
+++ b/include/khc.h
@@ -125,6 +125,8 @@ typedef struct khc {
 
 khc_code khc_set_zero(khc* khc);
 
+khc_code khc_set_zero_excl_cb(khc* khc);
+
 khc_code khc_perform(khc* khc);
 
 khc_code khc_set_host(khc* khc, const char* host);

--- a/src/khc.c
+++ b/src/khc.c
@@ -76,7 +76,12 @@ khc_code khc_set_zero(khc* khc) {
   khc->_cb_sock_close = NULL;
   khc->_sock_ctx_close = NULL;
 
-  // Elements consist request header.
+  khc_set_zero_excl_cb(khc);
+
+  return KHC_ERR_OK;
+}
+
+khc_code khc_set_zero_excl_cb(khc* khc) {
   khc->_req_headers = NULL;
   khc->_host[0] = '\0';
   khc->_path[0] = '\0';


### PR DESCRIPTION
Re-setting cb is tough work and not necessary in many cases.
Must provide option to skip that.